### PR TITLE
Fix Paginate(Keys()) max width

### DIFF
--- a/ext/model/src/main/scala/set/IndexSet.scala
+++ b/ext/model/src/main/scala/set/IndexSet.scala
@@ -82,11 +82,9 @@ object SchemaSet {
       extends SchemaSet(
         scope,
         KeyID.collID,
-        Union(
-          Seq(IndexJoin(Databases(scope), KeyByDatabase(scope)),
-              IndexSet(
-                DocumentsByCollection(scope),
-                Vector(IndexTerm(DocIDV(KeyID.collID.toDocID)))))))
+        IndexSet(
+          DocumentsByCollection(scope),
+          Vector(IndexTerm(DocIDV(KeyID.collID.toDocID)))))
 
   case class Tokens(scope: ScopeID)
       extends SchemaSet(


### PR DESCRIPTION
when running the bellow query in a database that contains many keys, it results in a bad request

```
> Paginate(Keys(), {size: 10})
Error: bad request
{
  errors: [
    {
      code: 'bad request',
      description: 'Query exceeds max width. Max: 100000, current: 118986.'
    }
  ]
}
```

even the `size` parameter is being ignored.

Turns out the Union of the indexes is not necessary as `DocumentsByCollection` will return all keys anyway.